### PR TITLE
Implemented tracer middle end and created HTTP metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 func main() {
+	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
 
 	command := app.NewServerCommand()

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fundoplicatedFundus/toy-server
 go 1.15
 
 require (
+	github.com/felixge/httpsnoop v1.0.2
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// requestsTotal keeps track of all of the requests made to our "cho"
+	// endpoint.
+	requestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "echo",
+			Name:      "requests_total",
+			Help:      "Total http requests to our echo JSON api",
+		},
+		[]string{
+			// HTTP status code.
+			"code",
+		},
+	)
+)
+
+// RegisterMetrics registers all metrics for the server.
+func RegisterMetrics() {
+	prometheus.MustRegister(requestsTotal)
+}

--- a/pkg/server/tracer.go
+++ b/pkg/server/tracer.go
@@ -1,0 +1,47 @@
+/*
+  Here we implement some middleware for obtaining info about requests.
+  However, if we implemen the app with a distributed tracing library
+  (i.e., Honeycomb) we get this for free and we get a platform for studying,
+  and making sense of our traffic.
+
+  This is just for show purposes.
+
+  If you are interested in seeing how this can be used in real lie checkout:
+  https://github.com/honeycombio/beeline-go/blob/main/wrappers/hnynethttp/nethttp.go
+*/
+package server
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/felixge/httpsnoop"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+// tracerMiddleware keeps track of useful info for all the incoming requests to
+// the HTTP handlers it wraps.
+func tracerMiddleware(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		// If we call the handler this way we can obtain some basic metrics that we
+		// can log.
+		m := httpsnoop.CaptureMetrics(h, w, r)
+
+		// Keep track of the request in the metrics.
+		requestsTotal.With(prometheus.Labels{"code": strconv.Itoa(m.Code)}).Inc()
+
+		// And keep track of the request in the logs.
+		log.WithFields(log.Fields{
+			"method":    r.Method,
+			"url":       r.URL,
+			"code":      m.Code,
+			"duration":  m.Duration,
+			"bytes":     m.Written,
+			"referer":   r.Header.Get("Referer"),
+			"userAgent": r.Header.Get("User-Agent"),
+		}).Debug("")
+	}
+
+	return http.HandlerFunc(fn)
+}


### PR DESCRIPTION
Before we begin implementing the core logic of our app, we want some
tooling to help us monitor and make sense of how our app is doing.
To that end we added a tracing middleware that will help us extract info
from all served requests.
We also implemented a prometheus metric for keeping track of response
codes for our server - this will be useful to showcase prometheus-style
metrics.

Worth noticing: if we instrument the application with a distributed
tracing SDK (e.g., honeycomb's beeline) we get both of the things
implemented here [and a lot more useful data] almost for free.
This is just to get an idea of how to monitor our app.

Signed-off-by: fundoplicatedFundus <jorge.alarc123@gmail.com>